### PR TITLE
Remove math transpilations from before std:: support

### DIFF
--- a/hipify_torch/cuda_to_hip_mappings.py
+++ b/hipify_torch/cuda_to_hip_mappings.py
@@ -59,23 +59,6 @@ if os.path.isfile(rocm_version_h):
             patch = int(match.group(1))
     rocm_version = (major, minor, patch)
 
-# List of math functions that should be replaced inside device code only.
-MATH_TRANSPILATIONS = collections.OrderedDict(
-    [
-        ("std::max", ("::max")),
-        ("std::min", ("::min")),
-        ("std::ceil", ("::ceil")),
-        ("std::floor", ("::floor")),
-        ("std::exp", ("::exp")),
-        ("std::log", ("::log")),
-        ("std::pow", ("::pow")),
-        ("std::fabs", ("::fabs")),
-        ("std::fmod", ("::fmod")),
-        ("std::remainder", ("::remainder")),
-        ("std::frexp", ("::frexp")),
-    ]
-)
-
 CUDA_TYPE_NAME_MAP = collections.OrderedDict(
     [
         ("CUresult", ("hipError_t", CONV_TYPE, API_DRIVER)),

--- a/hipify_torch/hipify_python.py
+++ b/hipify_torch/hipify_python.py
@@ -34,7 +34,6 @@ import warnings
 
 from . import constants
 from .cuda_to_hip_mappings import CUDA_TO_HIP_MAPPINGS
-from .cuda_to_hip_mappings import MATH_TRANSPILATIONS
 
 from typing import Dict, List, Iterator, Optional
 from collections.abc import Mapping, Iterable
@@ -472,22 +471,6 @@ def find_parentheses_group(input_string, start):
 
 
 RE_ASSERT = re.compile(r"\bassert[ ]*\(")
-
-
-def replace_math_functions(input_string):
-    """FIXME: Temporarily replace std:: invocations of math functions
-        with non-std:: versions to prevent linker errors NOTE: This
-        can lead to correctness issues when running tests, since the
-        correct version of the math function (exp/expf) might not get
-        called.  Plan is to remove this function once HIP supports
-        std:: math function calls inside device code
-
-    """
-    output_string = input_string
-    for func in MATH_TRANSPILATIONS:
-        output_string = output_string.replace(r'{}('.format(func), '{}('.format(MATH_TRANSPILATIONS[func]))
-
-    return output_string
 
 
 RE_SYNCTHREADS = re.compile(r":?:?\b(__syncthreads)\b(\w*\()")
@@ -928,10 +911,6 @@ def preprocessor(
     # Perform Kernel Launch Replacements
     if not hip_clang_launch:
         output_source = processKernelLaunches(output_source, stats)
-
-    # Replace std:: with non-std:: versions
-    if (filepath.endswith(".cu") or filepath.endswith(".cuh")) and "PowKernel" not in filepath:
-        output_source = replace_math_functions(output_source)
 
     # Include header if device code is contained.
     output_source = hip_header_magic(output_source)

--- a/hipify_torch/v2/cuda_to_hip_mappings.py
+++ b/hipify_torch/v2/cuda_to_hip_mappings.py
@@ -2,21 +2,6 @@ import collections
 
 """ Mapping of CUDA functions, include files, constants, and types to ROCm/HIP equivalents """
 
-# List of math functions that should be replaced inside device code only.
-MATH_TRANSPILATIONS = collections.OrderedDict([
-    ("std::max", ("::max")),
-    ("std::min", ("::min")),
-    ("std::ceil", ("::ceil")),
-    ("std::floor", ("::floor")),
-    ("std::exp", ("::exp")),
-    ("std::log", ("::log")),
-    ("std::pow", ("::pow")),
-    ("std::fabs", ("::fabs")),
-    ("std::fmod", ("::fmod")),
-    ("std::remainder", ("::remainder")),
-    ("std::frexp", ("::frexp")),
-])
-
 CUDA_TYPE_NAME_MAP = collections.OrderedDict([
     ("CUresult", "hipError_t"),
     ("cudaError_t", "hipError_t"),


### PR DESCRIPTION
## Motivation

Currently, both host-side and device code have std:: math functions mapped to the global namespace. This is an issue for hostside code, as many math functions such as std::max only have a integer version of ::max. Now that HIP supports std:: math functions, this should be safe to remove.

## Technical Details

Remove MATH_TRANSPILATIONS and associated functions

## Test Plan

Verify that hipified Transformer Engine code still works hostside and deviceside.

## Test Result

No issues found. 

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
