### PR TITLE
Add flag to skip replacing of math functions

### DIFF
--- a/cmake/Hipify.cmake
+++ b/cmake/Hipify.cmake
@@ -74,7 +74,7 @@ endfunction()
 # - CONFIG_FILE --> JSON format file, which provides additional arguments for hipify_cli.py file.
 #                   When set, it is having higher precendence over CUDA_SOURCE_DIR/HIP_SOURCE_DIR.
 function(hipify)
-  set(flags)
+  set(flags NO_MATH_REPLACE)
   set(singleValueArgs CUDA_SOURCE_DIR HIP_SOURCE_DIR CONFIG_FILE CUSTOM_MAP_FILE)
   set(multiValueArgs HEADER_INCLUDE_DIR IGNORES)
 
@@ -100,6 +100,9 @@ function(hipify)
     )
     if (HIPIFY_CUSTOM_MAP_FILE)
       list(APPEND HIPIFY_COMMAND --custom-map-json ${HIPIFY_CUSTOM_MAP_FILE})
+    endif()
+    if (HIPIFY_NO_MATH_REPLACE)
+      list(APPEND HIPIFY_COMMAND --no-math-replace)
     endif()
   else()
     message(FATAL_ERROR "Wrong invocation, either CUDA_SOURCE_DIR or CONFIG_FILE input parameter is required")

--- a/hipify_cli.py
+++ b/hipify_cli.py
@@ -84,6 +84,12 @@ def main():
         action='store_true',
         help="use new behavior introduced in version 2, removing caffe2 mappings")
 
+    parser.add_argument(
+        '--no-math-replace',
+        action='store_true',
+        help="Skip replacing std:: math functions in device code. Performance is not guaranteed.",
+        required=False)
+
 
     args = parser.parse_args()
     if(args.config_json):
@@ -135,6 +141,7 @@ def main():
             else args.ignores.strip("[]").split(";")
         header_include_dirs=args.header_include_dirs if type(args.header_include_dirs) is list \
             else args.header_include_dirs.strip("[]").split(";")
+        no_math_replace=args.no_math_replace
         custom_map_list=args.custom_map_json or ""
         extra_files = []
         hipify_extra_files_only = False
@@ -156,7 +163,8 @@ def main():
         extra_files=extra_files,
         is_pytorch_extension=True,
         hipify_extra_files_only=hipify_extra_files_only,
-        show_detailed=True)
+        show_detailed=True,
+        no_math_replace=no_math_replace)
 
     if dump_dict_file:
         with open(dump_dict_file, 'w') as dict_file:

--- a/hipify_torch/hipify_python.py
+++ b/hipify_torch/hipify_python.py
@@ -200,12 +200,13 @@ def preprocess_file_and_save_result(
         hip_clang_launch: bool,
         is_pytorch_extension: bool,
         clean_ctx: GeneratedFileCleaner,
-        show_progress: bool) -> None:
+        show_progress: bool,
+        no_math_replace: bool,) -> None:
     fin_path = os.path.abspath(os.path.join(output_directory, filepath))
     hipify_result = HipifyResult(current_state=CurrentState.INITIALIZED, hipified_path=fin_path)
     HIPIFY_FINAL_RESULT[fin_path] = hipify_result
     result = preprocessor(output_directory, filepath, all_files, header_include_dirs, stats,
-                          hip_clang_launch, is_pytorch_extension, clean_ctx, show_progress)
+                          hip_clang_launch, is_pytorch_extension, clean_ctx, show_progress, no_math_replace)
 
     # Show what happened
     if show_progress and "ignored" not in result.status:
@@ -797,7 +798,8 @@ def preprocessor(
         hip_clang_launch: bool,
         is_pytorch_extension: bool,
         clean_ctx: GeneratedFileCleaner,
-        show_progress: bool) -> HipifyResult:
+        show_progress: bool,
+        no_math_replace: bool,) -> HipifyResult:
     """ Executes the CUDA -> HIP conversion on the specified file. """
     fin_path = os.path.abspath(os.path.join(output_directory, filepath))
     hipify_result = HIPIFY_FINAL_RESULT[fin_path]
@@ -897,7 +899,7 @@ def preprocessor(
                     preprocess_file_and_save_result(output_directory,
                                                     header_filepath,
                                                     all_files, header_include_dirs, stats, hip_clang_launch,
-                                                    is_pytorch_extension, clean_ctx, show_progress)
+                                                    is_pytorch_extension, clean_ctx, show_progress, no_math_replace)
                 elif header_filepath in HIPIFY_FINAL_RESULT:
                     header_result = HIPIFY_FINAL_RESULT[header_filepath]
                     if header_result.current_state == CurrentState.INITIALIZED:
@@ -930,7 +932,9 @@ def preprocessor(
         output_source = processKernelLaunches(output_source, stats)
 
     # Replace std:: with non-std:: versions
-    if (filepath.endswith(".cu") or filepath.endswith(".cuh")) and "PowKernel" not in filepath:
+    if (not no_math_replace
+        and (filepath.endswith(".cu") or filepath.endswith(".cuh"))
+        and "PowKernel" not in filepath):
         output_source = replace_math_functions(output_source)
 
     # Include header if device code is contained.
@@ -1083,7 +1087,8 @@ def hipify(
     hip_clang_launch: bool = False,
     is_pytorch_extension: bool = False,
     hipify_extra_files_only: bool = False,
-    clean_ctx: Optional[GeneratedFileCleaner] = None
+    clean_ctx: Optional[GeneratedFileCleaner] = None,
+    no_math_replace: bool = False,
 ) -> HipifyFinalResult:
     if project_directory == "":
         project_directory = os.getcwd()
@@ -1152,7 +1157,8 @@ def hipify(
 
     for filepath in (all_files if not hipify_extra_files_only else extra_files):
         preprocess_file_and_save_result(output_directory, filepath, all_files, header_include_dirs,
-                                        stats, hip_clang_launch, is_pytorch_extension, clean_ctx, show_progress)
+                                        stats, hip_clang_launch, is_pytorch_extension, clean_ctx,
+                                        show_progress, no_math_replace)
 
     print(bcolors.OKGREEN + "Successfully preprocessed all matching files." + bcolors.ENDC, file=sys.stderr)
 

--- a/hipify_torch/v2/hipify_python.py
+++ b/hipify_torch/v2/hipify_python.py
@@ -205,12 +205,13 @@ def preprocess_file_and_save_result(
         hip_clang_launch: bool,
         is_pytorch_extension: bool,
         clean_ctx: GeneratedFileCleaner,
-        show_progress: bool) -> None:
+        show_progress: bool,
+        no_math_replace: bool,) -> None:
     fin_path = os.path.abspath(os.path.join(output_directory, filepath))
     hipify_result = HipifyResult(current_state=CurrentState.INITIALIZED, hipified_path=fin_path)
     HIPIFY_FINAL_RESULT[fin_path] = hipify_result
     result = preprocessor(output_directory, filepath, all_files, header_include_dirs, stats,
-                          hip_clang_launch, is_pytorch_extension, clean_ctx, show_progress)
+                          hip_clang_launch, is_pytorch_extension, clean_ctx, show_progress, no_math_replace)
 
     # Show what happened
     if show_progress and "ignored" not in result.status:
@@ -757,7 +758,8 @@ def preprocessor(
         hip_clang_launch: bool,
         is_pytorch_extension: bool,
         clean_ctx: GeneratedFileCleaner,
-        show_progress: bool) -> HipifyResult:
+        show_progress: bool,
+        no_math_replace: bool,) -> HipifyResult:
     """ Executes the CUDA -> HIP conversion on the specified file. """
     fin_path = os.path.abspath(os.path.join(output_directory, filepath))
     filepath = _to_unix_path(filepath)
@@ -843,7 +845,7 @@ def preprocessor(
                     preprocess_file_and_save_result(output_directory,
                                                     header_filepath,
                                                     all_files, header_include_dirs, stats, hip_clang_launch,
-                                                    is_pytorch_extension, clean_ctx, show_progress)
+                                                    is_pytorch_extension, clean_ctx, show_progress, no_math_replace)
                 elif header_filepath in HIPIFY_FINAL_RESULT:
                     header_result = HIPIFY_FINAL_RESULT[header_filepath]
                     if header_result.current_state == CurrentState.INITIALIZED:
@@ -876,7 +878,9 @@ def preprocessor(
         output_source = processKernelLaunches(output_source, stats)
 
     # Replace std:: with non-std:: versions
-    if (filepath.endswith((".cu", ".cuh"))) and "PowKernel" not in filepath:
+    if (not no_math_replace
+        and filepath.endswith((".cu", ".cuh"))
+        and "PowKernel" not in filepath):
         output_source = replace_math_functions(output_source)
 
     # Include header if device code is contained.
@@ -1028,7 +1032,8 @@ def hipify(
     hip_clang_launch: bool = False,
     is_pytorch_extension: bool = False,
     hipify_extra_files_only: bool = False,
-    clean_ctx: Optional[GeneratedFileCleaner] = None
+    clean_ctx: Optional[GeneratedFileCleaner] = None,
+    no_math_replace: bool = False,
 ) -> HipifyFinalResult:
     if project_directory == "":
         project_directory = os.getcwd()
@@ -1098,7 +1103,8 @@ def hipify(
 
     for filepath in (all_files if not hipify_extra_files_only else extra_files):
         preprocess_file_and_save_result(output_directory, filepath, all_files, header_include_dirs,
-                                        stats, hip_clang_launch, is_pytorch_extension, clean_ctx, show_progress)
+                                        stats, hip_clang_launch, is_pytorch_extension, clean_ctx,
+                                        show_progress, no_math_replace)
 
     print(bcolors.OKGREEN + "Successfully preprocessed all matching files." + bcolors.ENDC, file=sys.stderr)
 


### PR DESCRIPTION
## Motivation

TE unit tests use std:: math functions in files combining host/device code, transpilations cause issues
https://ontrack-internal.amd.com/browse/SWDEV-552194

## Technical Details

Added --no-math-replace flag to hipify-torch to allow users to skip the transpilation

## Test Plan

Tested that all std:: math functions work on device as is, although performance has not been tested. TE unit tests ran.

## Test Result

TE unit tests ran without transpilation successfully. All functions exist in std for device.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
