### PR TITLE
Avoid duplicated processing of header files

### DIFF
--- a/hipify_torch/v2/hipify_python.py
+++ b/hipify_torch/v2/hipify_python.py
@@ -3,7 +3,7 @@
 """ The Python Hipify script.
 ##
 # Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
-#               2017-2025 Advanced Micro Devices, Inc. and
+#               2017-2026 Advanced Micro Devices, Inc. and
 #                         Facebook Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -207,6 +207,9 @@ def preprocess_file_and_save_result(
         clean_ctx: GeneratedFileCleaner,
         show_progress: bool) -> None:
     fin_path = os.path.abspath(os.path.join(output_directory, filepath))
+    if fin_path in HIPIFY_FINAL_RESULT:
+        #the file has already been hipified as include to another file, no need to hipify again.
+        return
     hipify_result = HipifyResult(current_state=CurrentState.INITIALIZED, hipified_path=fin_path)
     HIPIFY_FINAL_RESULT[fin_path] = hipify_result
     result = preprocessor(output_directory, filepath, all_files, header_include_dirs, stats,


### PR DESCRIPTION
## Motivation

When hipify some source tree, headers are hipified several times the first time they are really hipified and after that skipped as not changed

## Technical Details

When building file list for hipification, hipify_torch explicitly adds all headers from header search directories.  Moreover, because it uses rglob for adding header, some headers might be added multiple times depending on search directories list.

## Test Plan

Run hipification of source tree and see how many times header files appear in progress log.

## Test Result

After change files appear in progress log once

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
